### PR TITLE
Update error handling macros and passthrough original tokens

### DIFF
--- a/crates/bevy_auto_plugin_shared/src/__private/expand/attr/auto_bind_plugin.rs
+++ b/crates/bevy_auto_plugin_shared/src/__private/expand/attr/auto_bind_plugin.rs
@@ -1,3 +1,4 @@
+use crate::util::macros::compile_error_with;
 use proc_macro2::TokenStream as MacroStream;
 
 pub fn auto_bind_plugin_inner(attr: MacroStream, input: MacroStream) -> syn::Result<MacroStream> {
@@ -29,5 +30,6 @@ pub fn auto_bind_plugin_inner(attr: MacroStream, input: MacroStream) -> syn::Res
 }
 
 pub fn auto_bind_plugin_outer(attr: MacroStream, input: MacroStream) -> MacroStream {
-    auto_bind_plugin_inner(attr, input).unwrap_or_else(|err| err.to_compile_error())
+    let og_input = input.clone();
+    auto_bind_plugin_inner(attr, input).unwrap_or_else(|err| compile_error_with!(err, og_input))
 }

--- a/crates/bevy_auto_plugin_shared/src/__private/expand/derive/auto_plugin.rs
+++ b/crates/bevy_auto_plugin_shared/src/__private/expand/derive/auto_plugin.rs
@@ -1,4 +1,4 @@
-use crate::util::macros::parse_macro_input2;
+use crate::util::macros::{ok_or_emit, parse_macro_input2};
 use proc_macro2::TokenStream as MacroStream;
 
 pub fn expand_derive_auto_plugin(input: MacroStream) -> MacroStream {
@@ -33,10 +33,7 @@ pub fn expand_derive_auto_plugin(input: MacroStream) -> MacroStream {
                 .collect()
         };
         for full_name in full_names {
-            let path_with_generics = match syn::parse_str::<syn::Path>(&full_name) {
-                Ok(p) => p,
-                Err(err) => return err.into_compile_error(),
-            };
+            let path_with_generics = ok_or_emit!(syn::parse_str::<syn::Path>(&full_name));
 
             auto_plugin_implemented = true;
 


### PR DESCRIPTION
To prevent the IDE from receiving user tokens late, this ensures the original tokens are passed through on compile errors.